### PR TITLE
4.x Add JUL appender for OpenTelemetry logging

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -589,6 +589,10 @@
             <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.telemetry</groupId>
+            <artifactId>helidon-telemetry-opentelemetry-logging-jul-appender</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.telemetry.testing</groupId>
             <artifactId>helidon-telemetry-testing-tracing</artifactId>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -798,6 +798,11 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.helidon.telemetry</groupId>
+                <artifactId>helidon-telemetry-opentelemetry-logging-jul-appender</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.helidon.telemetry.testing</groupId>
                 <artifactId>helidon-telemetry-testing-tracing</artifactId>
                 <version>${helidon.version}</version>

--- a/docs/src/main/asciidoc/se/metrics/metrics.adoc
+++ b/docs/src/main/asciidoc/se/metrics/metrics.adoc
@@ -111,7 +111,7 @@ include::{rootdir}/includes/metrics/metrics-shared.adoc[tag=usage-body]
 Helidon stores all meters in a _meter registry_. Typically, applications use the global meter registry which is the registry where Helidon stores built-in meters.
 Application code refers to the global registry using `Metrics.globalRegistry()`.
 
-
+[[usage-publishing]]
 include::{rootdir}/includes/metrics/metrics-shared.adoc[tag=usage-retrieving]
 
 

--- a/docs/src/main/asciidoc/se/telemetry/open-telemetry.adoc
+++ b/docs/src/main/asciidoc/se/telemetry/open-telemetry.adoc
@@ -34,6 +34,10 @@ include::{rootdir}/includes/se.adoc[]
 - <<API, API>>
 - <<Maven Coordinates, Maven Coordinates>>
 - <<Configuration, Configuration>>
+* <<common-config, Common Settings>>
+* <<tracing-config, Tracing>>
+* <<metrics-config, Metrics>>
+* <<logger-config, Logging>>
 - <<Additional Information, Additional Information>>
 
 == Overview
@@ -47,8 +51,9 @@ Helidon SE supports OpenTelemetry in several important ways:
 ** Programmatically, using the OpenTelemetry SDK API and the Helidon OpenTelemetry API
 
 * Conforms to the link:{semconv-link}[OpenTelemetry semantic conventions] for automatically-created spans and metrics for HTTP requests
+* Allows xref:{rootdir}/se/metrics/metrics.adoc#usage-publishing[publishing Helidon metrics] to backend systems using OTLP.
 
-OpenTelemetry models observability as a set of link:https://opentelemetry.io/docs/concepts/signals/[_signals_]. Each signal--for example metrics and tracing--is an origin of monitoring data, and each has configurable settings which control its behavior.
+OpenTelemetry models observability as a set of link:https://opentelemetry.io/docs/concepts/signals/[_signals_]. Each signal--for example metrics, tracing, and logging--is an origin of monitoring data, and each has configurable settings which control its behavior.
 
 Helidon's config support for OpenTelemetry has certain config attributes which apply to OpenTelemetry as a whole, others which pertain to individual signals, and still more which describe lower-level elements within a signal.
 
@@ -57,16 +62,8 @@ The Helidon OpenTelemetry configuration format, the Helidon OpenTelemetry API, a
 * <<top-level-config, Top-level telemetry>>
 ** Signals
 *** <<tracing-config, Tracing>>
-**** <<tracing-attributes-config, Attributes>>
-**** <<span-exporters-config, Span exporters>>
-**** <<span-processors-config, Span processors>>
-**** <<span-sampler-config, Span sampler>>
-**** <<span-limits-config, Span limits>>
 *** <<metrics-config, Metrics>>
-**** <<metric-attributes-config, Attributes>>
-**** <<metric-exporters-config, Metric exporters>>
-**** <<metric-readers-config, Metric readers>>
-**** <<metric-views-config, Metric views>>
+*** <<logger-config, Logging>>
 
 
 This document describes how to configure each level in the hierarchy and covers general topics related to Helidon's support of OpenTelemetry.
@@ -206,19 +203,24 @@ OpenTelemetry prescribes its own link:{metrics-semconv-link}[semantic convention
 Helidon supports the OpenTelemetry semantic conventions for outgoing traffic which uses the Helidon WebClient. See the xref:{rootdir}/se/webclient.adoc#_configuring_telemetry[Helidon WebClient documentation].
 
 === Specifying Additional OpenTelemetry Dependencies
-Most applications need to declare other runtime dependencies on OpenTelemetry artifacts because the configuration specifies--or the application code uses--particular OpenTelemetry types packaged in other artifacts. For example, OpenTelemetry packages various exporters individually.
+Most applications need to declare other runtime dependencies on OpenTelemetry artifacts because the configuration specifies--or the application code uses--particular OpenTelemetry types packaged in other artifacts. For example, OpenTelemetry exporters are packaged individually or as related groups. See <<note-about-exporter-dependencies, this section below>> for some specific dependencies to consider adding for particular exporters.
+
 These exporters transmit telemetry data using a different protocol. (See https://github.com/open-telemetry/opentelemetry-java/tree/{version-doc-opentelemetry}/exporters[this OpenTelemetry page].)
 
 
 == Configuration
-You can control almost all of OpenTelemetry's overall, tracing, and metrics runtime behavior using Helidon configuration settings. Helidon constructs an `OpenTelemetry` object using the configuration. The resulting `OpenTelemetry` instance includes an OpenTelemetry `TracerProvider` if the config specifies settings for it under `signals.tracing` and an OpenTelemetry `MeterProvider` if the config contains a `signals.metrics` section.
+You can control almost all of OpenTelemetry's overall, tracing, metrics, and logger runtime behavior using Helidon configuration settings. Helidon constructs an `OpenTelemetry` object using the configuration. The resulting `OpenTelemetry` instance reflects these settings from the Helidon configuration:
 
+* Settings that pertain to <<top-level-config,overall OpenTelemetry behavior>>, apart from a particular signal.
+* An OpenTelemetry tracer provider based on <<tracing-config,tracing configuration>> in  `signals.tracing`.
+* An OpenTelemetry meter provider based on <<metrics-config,metrics configuration>> in `signals.metrics`.
+* An OpenTelemetry logger provider based on <<logger-config,logger configuration>> in `signals.logging`.
 
 [[top-level-config]]
 === Controlling Overall OpenTelemetry Behavior
 Several settings control the operation of OpenTelemetry as a whole, as shown in the next table.
 
-include::{rootdir}/config/io_helidon_telemetry_otelconfig_OpenTelemetryConfig.adoc[tag=config,leveloffset=+1]
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_OpenTelemetryConfig.adoc[tag=config,leveloffset=+2]
 
 Notes:
 
@@ -231,56 +233,171 @@ This section describes settings that apply to multiple signal types.
 
 [[attributes-config]]
 ==== Assigning Attributes
-Configured attributes are key/value pairs that OpenTelemetry attaches to each transmission of a signal. OpenTelemetry supports attributes of type `String`, `long`, `double`, and `boolean`. The configuration structure groups attributes by type so Helidon knows precisely what type you intend for each attribute.
+Configured attributes are key/value pairs that OpenTelemetry attaches to each transmission of a signal. OpenTelemetry supports attributes of type `String`, `long`, `double`, and `boolean`. The Helidon configuration structure groups attributes by type so Helidon can indicate precisely to OpenTelemetry what type you intend for each attribute.
 
-[[tracing-config]]
-=== Controlling OpenTelemetry Tracing Behavior
-The settings under `settings.tracing` prepare an OpenTelemetry `TracerProvider`. When your application uses the Helidon tracing API to obtain a `Tracer`, Helidon uses the `TracerProvider` prepared from this config to create the tracer.
+You can add attributes to the configuration for any of the signals under the signal's `attributes` section.
 
-The next table describes the OpenTelemetry tracing settings.
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_TypedAttributes.adoc[tag=config,leveloffset=+3]
 
-include::{rootdir}/config/io_helidon_telemetry_otelconfig_OpenTelemetryTracingConfig.adoc[tag=config,leveloffset=+2]
+The following example shows attribute settings for the tracing signal.
 
-OpenTelemetry applies the defaults described in the next table.
+[source,yaml]
+.Example attribute settings
+----
+telemetry:
+  service: my-helidon-service
+  tracing:
+    attributes:
+      strings:
+        attr1: 12
+        attr5: "any old thing"
+        attr7: something
+      longs:
+        attr2: 12
+      doubles:
+        attr3: 24.5
+        attr6: 12
+      booleans:
+        attr4: true
+----
 
-.Default tracing settings applied by OpenTelemetry
+[[exporters-and-processors]]
+==== Configuring Exporters and Processors/Readers
+OpenTelemetry transmits the telemetry data it gathers to a backend system--such as Grafana, Signoz, Prometheus, Jaeger, or others--where you can view and query the data. OpenTelemetry goes through these distinct steps to gather and send data:
+
+. OpenTelemetry tracing and log record _processors_ and metrics _readers_ gather and process data observations.
+. OpenTelemetry _exporters_ associated with each processor or reader then transmit_ the data to one or more targets. Targets are typically backend systems but can be local ones for debugging. Each processor or reader uses one or more exporters to transmit telemetry data.
+
+The processor settings determine when and how often each uses its exporters to deliver data. Each exporter's settings prescribe where it should send the data, how to connect to a backend, etc.
+
+===== Configuring Processors (and readers)
+An OpenTelemetry span or log record processor or metric reader is one of the following types:
+
+* simple - The processor sends each telemetry observation to its exporters for transmission as soon as it receives the observation.
+* batch - The processor groups observations into batches and sends a batch at a time to its exporters for transmission.
+
+In the table below only the `type` and `exporters` setting apply to `simple`  processors; the other settings are for batch processors.
+
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_BatchProcessorConfig.adoc[tag=config,leveloffset=+3]
+
+===== Configuring Exporters
+Exporter objects in OpenTelemetry are specific to both _how_ they transmit telemetry data and _what_ signal they work with. Even so, many exporter settings are very similar across different signals. This section describes the behavior and configuration that is common among exporters. Refer to the sections below that describe each signal to see what additional exporter settings, if any, each signal adds.
+
+Helidon configuration supports several of the most popular exporters, discussed below.
+
+[[otlp-exporter-config]]
+====== Setting Up OTLP Exporters
+
+Most users choose an `Otlp` exporter which has two variations--one using gRPC and one using HTTP with protocol buffers--as indicated by the `protocol` setting.
+
+.Common Configuration for OTLP exporters
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_OtlpExporterConfig.adoc[tag=config,leveloffset=+3]
+
+.OpenTelemetry OTLP exporter defaults
 [cols="1,4"]
+|====
+| Setting | OpenTelemetry default
+
+| `compression` | `none`
+
+| `endpoint`
+| `grpc` protocol: http://localhost:4317
+
+`http/proto` protocol: http://localhost:4318
+| `protocol` | `grpc`
+| `retry-policy` | none
+| `timeout` | 10 seconds
+|====
+
+
+====== OTLP Retry Policy
+You can control how each exporter retries if a transmission to a backend fails.
+
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_RetryPolicyConfig.adoc[tag=config, leveloffset=+4]
+
+OpenTelemetry also supports a Zipkin exporter which it has recently deprecated.
+
+====== Zipkip Exporter
+.Configuration for Zipkin exporters
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_ZipkinExporterConfig.adoc[tag=config,leveloffset=+3]
+
+OpenTelemetry provides other exporters, often used for debugging:
+
+* `console`
++
+Writes telemetry data at the `INFO` level using the  `java.util.logging.Logger` for `io.opentelemetry.exporter.logging.Logging\{signal}Expoerter`
+* `logging-otlp`
++
+Writes telemetry data in JSON format to the logger for the particular OpenTelemetry implementation class (e.g., `OtlpJsonLoggingMetricExporter`).
+
+The `console` and `logging-otlp` have no configuration that is common across all signals.
+
+[[note-about-exporter-dependencies]]
+[NOTE]
+You need to add dependencies to your project for the exporters your application uses, even ones supported by Helidon config.
+
+The table below describes the exporter types that Helidon configuration supports and what dependency your project needs to support them.
+
+If you need to use an exporter that is _not_ in the table:
+
+* Add a dependency on the OpenTelemetry artifact that contains that exporter type.
+* Add application code that prepares the exporter instance.
+* Prepare the Helidon OpenTelemetry builders programmatically and add your exporter instance to the builder.
+
+In the table below, the Maven artifacts are all in the `io.opentelemetry` group.
+
+[cols="1,2,5a"]
 |===
-| Setting | OpenTelemetry default (and OpenTelemetry doc link)
+| Exporter type | OpenTelemetry Java Type | Artifact ID to add - ``see ``also the link:https://opentelemetry.io/docs/languages/java/sdk/#spanexporter[OpenTelemetry documentation]
 
-| `exporters` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[`otlp` with `grpc` protocol] - see "Properties: exporters, `otel.traces.exporter` property"
-| `processors` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-traces[`batch` with defaults] - see "Properties for batch span processor(s)"
-| `sampler` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-traces[`parentbased_always_on`] - see "Properties for sampler"
+.2+| <<otlp-exporter-config,`otlp`>> +
+(see `protocol` setting below)
+| `OtlpGrpc\{signal}Exporter`
+.2+|
+`opentelemetry-exporter-otlp`
+|`OtlpHttp\{signal}Exporter`
+|<<zipkin-exporter-config,`zipkin`>> | `ZipkinSpanExporter` a|
+`opentelemetry-exporter-zipkin`
+| `console` | `Logging\{signal}Exporter`
+.3+|
+`opentelemetry-exporter-logging`
+| `logging_otlp` | `OtlpJsonLogging\{signal}Exporter`
 
-| `span-limits`
-| See link:https://opentelemetry.io/docs/languages/java/configuration/#properties-traces[tracing] "Properties for span limits"
+`SystemOutLogRecordExporeter`
 |===
 
 
 
-Sections below describe how to set up the tracing signal configuration:
 
-- <<tracing-attributes-config, Assigning Span Attributes>>
-- <<associating-exporters-and-processors, Associating Exporters and Processors>>
-- <<span-exporters-config, Configuring Span Exporters>>
-- <<span-processors-config, Configuring Span Processors>>
-- <<span-sampler-config, Configuring the Span Sampler>>
-- <<span-limits-config, Configuring the Span Limits>>
+[[zipkin-exporter-config]]
+===== Configuring a Zipkin Exporter
 
-[[tracing-attributes-config]]
-==== Assigning Span Attributes
-Helidon adds any configured attribute name and value pairs to every tracing span automatically. See <<attributes-config,the earlier section on attributes>> for more information.
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_ZipkinExporterConfig.adoc[tag=config,leveloffset=+2]
 
-[[associating-exporters-and-processors]]
-==== Associating Exporters and Processors
-Ultimately, OpenTelemetry transmits the telemetry data it gathers to a backend system--such as Grafana, Prometheus,  Jaeger, or others--where you can view and query the data. OpenTelemetry tracing first _processes_ each data observation within the JVM and then _exports_ the processed data to one or more backends. Each span processor uses one or more span exporters to transmit telemetry data.
+The link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[OpenTelemetry documentation] describes the defaults; see the "Properties for Zipkin span exporters" section there.
 
-You link processors and exporters in config selectively as follows:
+.OpenTelemetry defaults for Zipkin exporters
+[cols="1,4"]
+|====
+| Setting | OpenTelemetry default value
 
-* Name each exporter if you have more than one.
-* List, for each processor, the names of exporters it should use. Omitting a processor's list of exporter names causes the processor to use all configured exporters.
+| `compression` | `none`
+| `encoder` | `JSON_V2`
+| `endpoint` | http://localhost:9411/api/v2/spans
+| `timeout` | 10 seconds
+|====
 
-The following examples show increasingly-complicated scenarios:
+
+// ====
+===== Associating Each Processor and Reader with its Exporters
+In configuration, you link processors and readers with the exporters you want each to use as follows:
+
+* For clarity, name each exporter if you have more than one.
+* Optionally specify for each processor or reader the names of the exporters it should use.
++
+If you omit the exporter names for a processor or reader, Helidon associates it with all configured exporters. If you configure no exporters explicitly, Helidon associates the OpenTelemetry default exporter with the processor or reader.
+
+The following examples show increasingly-complicated scenarios using tracing as the signal:
 
 * Default
 * Minimal configuration
@@ -346,104 +463,38 @@ telemetry:
         exporters: ["alternate-otlp"]
 ----
 
-[[span-processors-config]]
-==== Configuring Span Processors
-An OpenTelemetry span processor is one of the following types:
+// Following horizontal line separates the nested "common config" section from the upcoming major section about configuring tracing. Otherwise it's a little hard to tell on our rendered page that we're starting a new major topic.
+'''
 
-* simple - The processor sends each telemetry observation to its exporters for transmission as soon as it receives the observation.
-* batch - The processor groups observations into batches and sends a batch at a time to its exporters for transmission.
+[[tracing-config]]
+=== Controlling OpenTelemetry Tracing Behavior
+The settings under `signals.tracing` prepare an OpenTelemetry `TracerProvider`. When your application uses the Helidon tracing API to obtain a `Tracer`, Helidon uses the `TracerProvider` prepared from this config to create the tracer.
 
-In the table below only the `type` and `exporters` setting apply to `simple` span processors; the other settings are for batch processors.
+The next table describes the OpenTelemetry tracing settings.
 
-include::{rootdir}/config/io_helidon_telemetry_otelconfig_BatchSpanProcessorConfig.adoc[tag=config,leveloffset=+3]
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_OpenTelemetryTracingConfig.adoc[tag=config,leveloffset=+2]
 
-[[span-exporters-config]]
-==== Configuring Span Exporters
-OpenTelemetry supports many types of exporters, each with its own configurable settings. Helidon configuration supports several of the most popular exporters, listed in the table below.
+OpenTelemetry applies the defaults described in the next table.
 
-[NOTE]
-You need to add dependencies to your project for the exporters your application uses, even ones supported by Helidon config.
-
-If you need to use an exporter that is _not_ in the table:
-
-* Add a dependency on the OpenTelemetry artifact that contains that exporter type.
-* Add application code that prepares the exporter instance.
-* Prepare the Helidon OpenTelemetry builders programmatically and add your exporter instance to the builder.
-
-
-
-[cols="1,2,5a"]
-|===
-| Exporter type | OpenTelemetry Java Type | Dependency to add - see also the link:https://opentelemetry.io/docs/languages/java/sdk/#spanexporter[OpenTelemetry documentation]
-
-.2+| <<otlp-exporter-config,`otlp`>> +
-(see `protocol` setting below)
-| `OtlpGrpcSpanExporter`
-.2+|
-[source,xml]
-----
-<dependency>
-  <groupId>io.opentelemetry</groupId>
-  <artifactId>opentelemetry-exporter-otlp</artifactId>
-</dependency>
-----
-|`OtlpHttpSpanExporter`
-|<<zipkin-exporter-config,`zipkin`>> | `ZipkinSpanExporter`|
-[source,xml]
-----
-<dependency>
-  <groupId>io.opentelemetry</groupId>
-  <artifactId>opentelemetry-exporter-zipkin</artifactId>
-</dependency>
-----
-| `console` | `LoggingSpanExporter` |
-included
-| `logging_otlp` | `OtlpJsonLoggingSpanExporter` | included
-|===
-
-[[otlp-exporter-config]]
-===== Configuring an OTLP Exporter
-
-The configuration for OTLP exporters is the same, regardless of which protocol you choose: `grpc` (the default) or `http/proto`. OpenTelemetry applies some different default values depending on the protocol.
-
-include::{rootdir}/config/io_helidon_telemetry_otelconfig_OtlpExporterConfig.adoc[tag=config,leveloffset=+2]
-
-The link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[OpenTelemetry documentation] describes the defaults; see the "Properties for `otlp `span, metric, and log exporters" section there.
-
-.OpenTelemetry defaults for tracing
+.Default tracing settings applied by OpenTelemetry
 [cols="1,4"]
-|====
+|===
 | Setting | OpenTelemetry default (and OpenTelemetry doc link)
 
-| `compression` | `none`
+| `exporters` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[`otlp` with `grpc` protocol] - see "Properties: exporters, `otel.traces.exporter` property"
+| `processors` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-traces[`batch` with defaults] - see "Properties for batch span processor(s)"
+| `sampler` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-traces[`parentbased_always_on`] - see "Properties for sampler"
 
-| `endpoint`
-| `grpc` protocol: http://localhost:4317
+| `span-limits`
+| See link:https://opentelemetry.io/docs/languages/java/configuration/#properties-traces[tracing] "Properties for span limits"
+|===
 
-`http/proto` protocol: http://localhost:4318
-| `protocol` | `grpc`
-| `retry-policy` | none
-| `timeout` | 10 seconds
-|====
-[[zipkin-exporter-config]]
-===== Configuring a Zipkin Exporter
+Refer to the earlier sections about <<attributes-config,configuring attributes>> and <<exporters-and-processors,configuring processors and exporters>>.
 
-include::{rootdir}/config/io_helidon_telemetry_otelconfig_ZipkinExporterConfig.adoc[tag=config,leveloffset=+2]
+Sections below describe how to set up the tracing signal configuration:
 
-The link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[OpenTelemetry documentation] describes the defaults; see the "Properties for Zipkin span exporters" section there.
-
-.OpenTelemetry defaults for Zipkin exporters
-[cols="1,4"]
-|====
-| Setting | OpenTelemetry default value
-
-| `compression` | `none`
-| `encoder` | `JSON_V2`
-| `endpoint` | http://localhost:9411/api/v2/spans
-| `timeout` | 10 seconds
-|====
-
-
+- <<span-sampler-config, Configuring the Span Sampler>>
+- <<span-limits-config, Configuring the Span Limits>>
 
 [[span-sampler-config]]
 ==== Configuring the Span Sampler
@@ -480,9 +531,11 @@ The link:https://opentelemetry.io/docs/languages/java/sdk/#sampler[OpenTelemetry
 
 [[metrics-config]]
 === Controlling OpenTelemetry Metrics Behavior
-The settings under `settings.metrics` prepare an OpenTelemetry `MeterProvider`. If your code uses the OpenTelemetry API to obtain an OpenTelemetry meter, meter provider, or meter builder, OpenTelemetry uses the `MeterProvider` prepared from this configuration.
+The settings under `signals.metrics` prepare an OpenTelemetry `MeterProvider`. If your code uses the OpenTelemetry API to obtain an OpenTelemetry meter, meter provider, or meter builder, OpenTelemetry uses the `MeterProvider` prepared from this configuration.
 
 The sections below describe Helidon config settings that correspond very directly to OpenTelemetry builders for the relevant OpenTelemetry type. Refer to the relevant OpenTelemetry documentation or Javadoc to understand the effect each setting has.
+
+See the earlier sections about <<attributes-config,configuring attributes>> and <<exporters-and-processors,configuring processors and exporters>>. A <<metric-exporters-config,later section below>> describes some additional attributes on metrics exporters.
 
 The next table describes the OpenTelemetry metrics settings.
 
@@ -495,14 +548,12 @@ OpenTelemetry applies the defaults described in the next table.
 |===
 | Setting | OpenTelemetry default (and OpenTelemetry doc link)
 
-| `exporters` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[`otlp` with `grpc` protocol] - see "Properties: exporters, `otel.metrics.exporter` property"]
+| `exporters` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[`otlp` with `grpc` protocol] - see that web page's "Properties: exporters, `otel.metrics.exporter` property"] section.
 | `readers` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-metrics[`PeriodicMetricReader`] with an interval of one minute
 |===
 
-Sections below describe how to set up the metric signal configuration:
+Sections below describe how to set up the configuration that is specific to the metrics signal:
 
-- <<metric-attributes-config, Assigning Metric Attributes>>
-- <<associating-exporters-and-readers, Associating Exporters and Metric Readers>>
 - <<metric-exporters-config, Configuring Metric Exporters>>
 - <<metric-readers-config, Configuring Metric Readers>>
 - <<metric-views-config, Configuring Metric Views>>
@@ -558,24 +609,9 @@ telemetry:
 <9> Declares a single view to influence influence the transmission of the `my-counter` counter data.
 
 
-[[metric-attributes-config]]
-==== Metric Attributes
-Helidon adds any configured attribute name and value pairs to every OpenTelemetry metric signal automatically. See <<attributes-config,the earlier section on attributes>> for more information.
-
-[[associating-exporters-and-readers]]
-Ultimately, OpenTelemetry transmits the telemetry data it gathers to a backend system--such as Grafana, Prometheus,  Jaeger, or others--where you can view and query the data. OpenTelemetry metrics first _reads_ each data observation within the JVM and then _exports_ the processed data to one or more backends. Each metric reader uses a metric exporter to transmit telemetry data.
-
-You link readers and exporters in config selectively as follows:
-
-* Name each exporter if you have more than one.
-* Optionally specify, for each reader, the names of the exporter it should use. If you omit the exporter name for a reader, Helidon chooses the exporter as follows:
-** If you configure no exporters, Helidon lets OpenTelemetry use its default.
-** If you configure one exporter, Helidon associates that one with the reader.
-** If you configure more than one exporter, Helidon reports a configuration error because it cannot determine which exporter you want to use for the reader.
-
 [[metric-exporters-config]]
 ==== Metric Exporters
-OpenTelemetry uses one or more metric exporters to transmit metrics data. If you omit any values, OpenTelemetry applies its defaults.
+The configuration for metrics exporters has several additional settings beyond those described earlier for exporters in general.
 
 include::{rootdir}/config/io_helidon_telemetry_otelconfig_MetricExporterConfig.adoc[tag=config,leveloffset=+2]
 
@@ -592,11 +628,6 @@ You can configure the exponential histogram aggregation behavior.
 
 include::{rootdir}/config/io_helidon_telemetry_otelconfig_Base2ExponentialHistogramAggregationConfig.adoc[tag=config, leveloffset=+2]
 
-
-===== Retry Policy
-You can control how each exporter retries if a transmission to a backend fails.
-
-include::{rootdir}/config/io_helidon_telemetry_otelconfig_RetryPolicyConfig.adoc[tag=config, leveloffset=+2]
 
 [[metric-readers-config]]
 ==== Metric Readers
@@ -617,6 +648,96 @@ include::{rootdir}/config/io_helidon_telemetry_otelconfig_ViewRegistrationConfig
 The instrument selector controls which meters this view reflects.
 
 include::{rootdir}/config/io_helidon_telemetry_otelconfig_InstrumentSelectorConfig.adoc[tag=config, leveloffset=+2]
+
+[[logger-config]]
+=== Controlling OpenTelemetry Logger Behavior
+The settings under `signal.logging` prepare an OpenTelemetry `LoggerProvider.
+
+The sections below describe Helidon config settings that correspond directly to OpenTelemetry builders for the relevant OpenTelemetry type. Refer to the relevant OpenTelemetry documentation or Javadoc to understand the effect each setting has.
+
+The next table describes the OpenTelemetry logging settings.
+
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_OpenTelemetryLoggingConfig.adoc[tag=config,leveloffset=+2]
+
+OpenTelemetry uses the following defaults:
+
+.Default logging settings applied by OpenTelemetry
+[cols="1,4"]
+|===
+| Setting | OpenTelemetry default
+
+| `exporters` | none
+| `minimum-severity` | undefined severity number
+| `processors` | no-op processor
+| `trace-based` | `false`
+|===
+
+
+Refer to the earlier sections about <<attributes-config,configuring attributes>> and <<exporters-and-processors,configuring processors and exporters>>.
+
+Sections below explain how to set up the configuration that is specific to the logging signal:
+
+- <<configuring-log-limits, Configuring Log Limits>>
+
+
+
+[[configuring-log-limits]]
+==== Configuring Log Limits
+
+For defaults, Helidon defers to the OpenTelemetry defaults, listed below.
+
+include::{rootdir}/config/io_helidon_telemetry_otelconfig_LogLimitsConfig.adoc[tag=config,leveloffset=+3]
+
+OpenTelemetry applies the following defaults:
+
+.Default log limit settings applied by OpenTelemetry
+[cols="1,4"]
+|===
+| Setting | OpenTelemetry default
+
+| `max-attribute-value-length` | `Integer.MAX_VALUE`
+| `max-number-of-attributes` | 128
+| `exporters` | link:https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters[`otlp` with `grpc` protocol] - see that web page's "Properties: exporters, `otel.logger.exporter` property" section.
+| `log-limits` | `max-
+| `processors` | https://opentelemetry.io/docs/languages/java/configuration/#properties-logs[`otlp`] - see that web page's "Properties: logs" section.
+|===
+
+The following example illustrates some of the ways you can configure OpenTelemetry logger behavior. It is neither complete nor typical.
+
+.Example OpenTelemetry Logger Configuration
+[source,yaml]
+----
+telemetry:
+  service: test-tel-logging
+  global: false
+  signals:
+    logging:                              # <1>
+      minimum-severity: TRACE             # <2>
+      log-limits:                         # <3>
+        max-attribute-value-length: 20
+        max-number-of-attributes: 14
+      processors:                         # <4>
+        - type: batch
+          schedule-delay: PT10S
+          max-queue-size: 15
+          max-export-batch-size: 5
+          timeout: PT30S
+        - type: simple
+      exporters:                          # <5>
+        - name: exp-1
+          endpoint: "http://host:1234"
+----
+<1> Introduces the logger configuration.
+<2> Sets the minimum log level severity to of log messages to send to the backend system.
+<3> Configures limits related to attributes that accompany log messages.
+<4> Prescribes the logger processors.
+<5> Prescribes the logger exporters.
+
+[[logger-exporters-and-readers]]
+==== Logger Exporters and Processors
+You associate each logger processor with a logger exporter using the exporter's name.
+See the <<exporters-and-processors,earlier section>> for more information.
+
 
 == Additional Information
 

--- a/http/media/json/src/main/java/io/helidon/http/media/json/JsonSupport.java
+++ b/http/media/json/src/main/java/io/helidon/http/media/json/JsonSupport.java
@@ -35,6 +35,10 @@ import io.helidon.json.JsonValue;
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class JsonSupport extends MediaSupportBase<JsonSupportConfig> implements RuntimeType.Api<JsonSupportConfig> {
+    /**
+     * Generic type of this type, as it is required when this media type is used programmatically.
+     */
+    public static final GenericType<JsonObject> JSON_OBJECT_TYPE = GenericType.create(JsonObject.class);
 
     static final String ID = "json";
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/BatchProcessorConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/BatchProcessorConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
- * Configuration for a batch span processor.
+ * Configuration for a batch processor.
  */
 @Prototype.Configured
 @Prototype.Blueprint
-interface BatchSpanProcessorConfigBlueprint extends SpanProcessorConfigBlueprint {
+interface BatchProcessorConfigBlueprint extends ProcessorConfigBlueprint {
 
     /**
      * Delay between consecutive exports.
@@ -37,16 +37,16 @@ interface BatchSpanProcessorConfigBlueprint extends SpanProcessorConfigBlueprint
     Optional<Duration> scheduleDelay();
 
     /**
-     * Maximum number of spans retained before discarding excess unexported ones.
-     * @return maximum number of spans kept
+     * Maximum number of items retained before discarding excess unexported ones.
+     * @return maximum number of items kept
      */
     @Option.Configured
     Optional<Integer> maxQueueSize();
 
     /**
-     * Maximum number of spans batched for export together. OpenTelemetry requires this value to not exceed
+     * Maximum number of items batched for export together. OpenTelemetry requires this value to not exceed
      * the {@link #maxQueueSize()}.
-     * @return maximum number of spans batched
+     * @return maximum number of items batched
      */
     @Option.Configured
     Optional<Integer> maxExportBatchSize();

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LogExporterType.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LogExporterType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.telemetry.otelconfig;
+
+/**
+ * Types of OpenTelemetry log exporters supported via Helidon telemetry logging configuration.
+ * <p>
+ * See <a href="https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters">OTel exporters</a>.
+ */
+public enum LogExporterType {
+
+    /*
+    Enum values are chosen to be the upper-case version of the OTel setting values so Helidon's built-in enum config mapping
+    works.
+     */
+
+    /**
+     * OpenTelemetry Protocol {@link io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter} and
+     * {@link io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder}.
+     */
+    OTLP, // There are different defaults for the different subtypes of OTLP exporters.
+
+    /**
+     * Console {@link io.opentelemetry.exporter.logging.SystemOutLogRecordExporter}.
+     */
+    CONSOLE,
+
+    /**
+     * Writes logs to a Logger in OTLP JSON
+     * format {@link io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogRecordExporter}.
+     */
+    LOGGING_OTLP;
+
+    static final LogExporterType DEFAULT = OTLP;
+}

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LogLimitsConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LogLimitsConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.helidon.telemetry.otelconfig;
+
+import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
+/**
+ * Settings for log limits.
+ */
 @Prototype.Configured
 @Prototype.Blueprint
-interface SpanExporterConfigBlueprint {
+interface LogLimitsConfigBlueprint {
 
     /**
-     * Span exporter type.
+     * Maximum number of attributes allowed.
      *
-     * @return exporter type
+     * @return maximum number of attributes
      */
     @Option.Configured
-    @Option.Default("DEFAULT")
-    SpanExporterType type();
+    Optional<Integer> maxNumberOfAttributes();
 
+    /**
+     * Maximum length of an attribute value.
+     *
+     * @return max length of an attribute value
+     */
+    @Option.Configured
+    Optional<Integer> maxAttributeValueLength();
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LogRecordExporterConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LogRecordExporterConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.helidon.telemetry.otelconfig;
 
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
 /**
- * Span Processor type. Batch is default for production.
+ * Settings for a log record exporter.
  */
-public enum SpanProcessorType {
-
-    /*
-    Enum values are chosen to be the upper-case version of the OTel setting values so Helidon's built-in enum config mapping
-    works.
-     */
+@Prototype.Configured
+@Prototype.Blueprint
+interface LogRecordExporterConfigBlueprint extends OtlpExporterConfigBlueprint {
 
     /**
-     * Simple Span Processor.
+     * Logger exporter type.
+     *
+     * @return exporter type
      */
-    SIMPLE,
-    /**
-     * Batch Span Processor.
-     */
-    BATCH;
+    @Option.Configured
+    @Option.Default("DEFAULT")
+    LogExporterType type();
 
 }
-

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LoggingBuilderInfo.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/LoggingBuilderInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,9 @@
 
 package io.helidon.telemetry.otelconfig;
 
-import io.helidon.builder.api.Option;
-import io.helidon.builder.api.Prototype;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 
-@Prototype.Configured
-@Prototype.Blueprint
-interface SpanExporterConfigBlueprint {
-
-    /**
-     * Span exporter type.
-     *
-     * @return exporter type
-     */
-    @Option.Configured
-    @Option.Default("DEFAULT")
-    SpanExporterType type();
-
+record LoggingBuilderInfo(SdkLoggerProviderBuilder sdkLoggerProviderBuilder,
+                          AttributesBuilder attributesBuilder) {
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
-import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 
@@ -80,34 +78,24 @@ interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTele
      *
      * @return tracing settings
      */
-    @Option.Access("")
     @Option.Configured("signals.tracing")
-    Optional<OpenTelemetryTracingConfig> tracingConfig();
+    Optional<OpenTelemetryTracingConfig> tracing();
 
     /**
      * OpenTelemetry metrics settings.
      *
      * @return metrics settings
      */
-    @Option.Access("")
     @Option.Configured("signals.metrics")
-    Optional<OpenTelemetryMetricsConfig> metricsConfig();
+    Optional<OpenTelemetryMetricsConfig> metrics();
 
     /**
-     * Sets the tracer provider that OpenTelemetry should use. Applications can invoke this method to set the OpenTelemetry
-     * tracer provider rather than having Helidon prepare one from the tracing-related config settings.
+     * OpenTelemetry logging settings.
      *
-     * @return OpenTelemetry tracer provider
+     * @return logging settings
      */
-    Optional<TracerProvider> tracerProvider();
-
-    /**
-     * Sets the meter provider that OpenTelemetry should use. Applications can invoke this method to set the OpenTelemetry
-     * meter provider rather than having Helidon prepare one from the metrics-releated config settings.
-     *
-     * @return OpenTelemetry meter provider
-     */
-    Optional<MeterProvider> meterProvider();
+    @Option.Configured("signals.logging")
+    Optional<OpenTelemetryLoggingConfig> logging();
 
     /**
      * The {@link io.opentelemetry.api.OpenTelemetry} instance to use for telemetry.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
@@ -43,8 +43,8 @@ final class OpenTelemetryConfigSupport {
                     TextMapPropagator.composite(target.propagators())));
         }
 
-        if (target.tracingConfig().isPresent()) {
-            var tracingConfig = target.tracingConfig().get();
+        if (target.tracing().isPresent()) {
+            var tracingConfig = target.tracing().get();
             var tracingBuilderInfo = tracingConfig.tracingBuilderInfo();
             var sdkTracerProviderBuilder = tracingBuilderInfo.sdkTracerProviderBuilder();
 
@@ -57,8 +57,8 @@ final class OpenTelemetryConfigSupport {
             openTelemetrySdkBuilder.setTracerProvider(sdkTracerProviderBuilder.build());
         }
 
-        if (target.metricsConfig().isPresent()) {
-            var metricsConfig = target.metricsConfig().get();
+        if (target.metrics().isPresent()) {
+            var metricsConfig = target.metrics().get();
             var metricsBuilderInfo = metricsConfig.metricsBuilderInfo();
             var sdkMeterProviderBuilder = metricsBuilderInfo.sdkMeterProviderBuilder();
 
@@ -69,6 +69,20 @@ final class OpenTelemetryConfigSupport {
             sdkMeterProviderBuilder.setResource(resource);
 
             openTelemetrySdkBuilder.setMeterProvider(sdkMeterProviderBuilder.build());
+        }
+
+        if (target.logging().isPresent()) {
+            var loggingConfig = target.logging().get();
+            var loggingBuilderInfo = loggingConfig.loggingBuilderInfo();
+            var sdkLoggerProviderBuilder = loggingBuilderInfo.sdkLoggerProviderBuilder();
+
+            var attributesBuilder = loggingConfig.loggingBuilderInfo().attributesBuilder();
+            attributesBuilder.put(ServiceAttributes.SERVICE_NAME, target.service().orElseThrow());
+
+            var resource = Resource.getDefault().merge(Resource.create(attributesBuilder.build()));
+            sdkLoggerProviderBuilder.setResource(resource);
+
+            openTelemetrySdkBuilder.setLoggerProvider(sdkLoggerProviderBuilder.build());
         }
 
         var sdk = openTelemetrySdkBuilder.build();

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigBlueprint.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.otelconfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.sdk.logs.LogLimits;
+import io.opentelemetry.sdk.logs.LogRecordProcessor;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+
+/**
+ * Configuration settings for OpenTelemetry logging. Optional values left unspecified in the configuration defer to the
+ * OpenTelemetry defaults.
+ */
+@Prototype.Configured
+@Prototype.Blueprint(decorator = OpenTelemetryLoggingConfigSupport.BuilderDecorator.class)
+@Prototype.CustomMethods(OpenTelemetryLoggingConfigSupport.CustomMethods.class)
+interface OpenTelemetryLoggingConfigBlueprint {
+
+    /**
+     * Whether the OpenTelemetry logger should be enabled. (Passed to OpenTelemetry.)
+     *
+     * @return true if the OpenTelemetry logger should be enabled, false otherwise
+     */
+    @Option.Configured
+    Optional<Boolean> enabled();
+
+    /**
+     * Minimum severity level of log records to process.
+     *
+     * @return minimum severity level
+     */
+    @Option.Configured
+    Optional<Severity> minimumSeverity();
+
+    /**
+     * Whether to include <em>only</em> log records from traces which are sampled. Defaults to the OpenTelemetry default.
+     *
+     * @return whether to restrict exported log records to only those from sampled traces
+     */
+    @Option.Configured
+    Optional<Boolean> traceBased();
+
+    /**
+     * Log limits to apply to log transmission.
+     *
+     * @return log limits
+     */
+    @Option.Configured
+    Optional<LogLimits> logLimits();
+
+    /**
+     * Settings for logging processors.
+     *
+     * @return logging processors
+     */
+    @Option.Access("")
+    @Option.Configured("processors")
+    @Option.Singular
+    List<ProcessorConfig> processorConfigs();
+
+    /**
+     * Pre-constructed (non-configured) logging processors.
+     *
+     * @return logging processors
+     */
+    @Option.Singular
+    List<LogRecordProcessor> processors();
+
+    /**
+     * Log record exporters.
+     * <p>
+     * The key in the map is a unique name--of the user's choice--for the exporter config settings.
+     * The {@link ProcessorConfig#exporters()} config setting for a processor config specifies zero
+     * or more of these names to associate the exporters built from the exporter configs with the processor
+     * built from the processor config.
+     *
+     * @return log record exporters
+     */
+    @Option.Access("")
+    @Option.Configured("exporters")
+    @Option.Singular
+    Map<String, LogRecordExporter> exporterConfigs();
+
+    /**
+     * Name/value pairs passed to OpenTelemetry.
+     *
+     * @return typed attribute settings
+     */
+    @Option.Configured
+    Optional<AttributesBuilder> attributes();
+
+    /**
+     * Information shared with the parent prototype.
+     *
+     * @hidden internal use only
+     * @return shared logging builder information
+     */
+    @Option.Access("")
+    LoggingBuilderInfo loggingBuilderInfo();
+
+}

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,45 +22,52 @@ import io.helidon.config.Config;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.SpanLimits;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.logs.LogLimits;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.logs.internal.LoggerConfig;
 
-class OpenTelemetryTracingConfigSupport {
+class OpenTelemetryLoggingConfigSupport {
 
-    private static final System.Logger LOGGER = System.getLogger(OpenTelemetryTracingConfigSupport.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(OpenTelemetryLoggingConfigSupport.class.getName());
 
-    static class BuilderDecorator implements Prototype.BuilderDecorator<OpenTelemetryTracingConfig.BuilderBase<?, ?>> {
+    private OpenTelemetryLoggingConfigSupport() {
+    }
+
+    static class BuilderDecorator implements Prototype.BuilderDecorator<OpenTelemetryLoggingConfig.BuilderBase<?, ?>> {
 
         @Override
-        public void decorate(OpenTelemetryTracingConfig.BuilderBase<?, ?> target) {
+        public void decorate(OpenTelemetryLoggingConfig.BuilderBase<?, ?> target) {
 
             // Associate each processor with either its named exporter(s) or all exporters.
 
             Errors.Collector errorsCollector = Errors.collector();
 
-            var sdkTracerProviderBuilder = SdkTracerProvider.builder();
+            var loggerConfigBuilder = LoggerConfig.builder();
+            target.enabled().ifPresent(loggerConfigBuilder::setEnabled);
+            target.minimumSeverity().ifPresent(loggerConfigBuilder::setMinimumSeverity);
+            target.traceBased().ifPresent(loggerConfigBuilder::setTraceBased);
 
-            target.sampler().ifPresent(sdkTracerProviderBuilder::setSampler);
-            target.spanLimits().ifPresent(sdkTracerProviderBuilder::setSpanLimits);
+            var sdkLoggerProviderBuilder = SdkLoggerProvider.builder();
+
+            target.logLimits().ifPresent(limits -> sdkLoggerProviderBuilder.setLogLimits(() -> limits));
 
             // Add configured processors to any the app added programmatically.
             target.addProcessors(target.processorConfigs().stream()
-                                         .map(processorConfig -> OtelConfigSupport.createSpanProcessor(processorConfig,
+                                         .map(processorConfig -> OtelConfigSupport.createLogRecordProcessor(processorConfig,
                                                                                                        target.exporterConfigs(),
                                                                                                        errorsCollector))
                                          .toList());
 
-            target.processors().forEach(sdkTracerProviderBuilder::addSpanProcessor);
+            target.processors().forEach(sdkLoggerProviderBuilder::addLogRecordProcessor);
 
             // Exporters are not set on the SDK builder directly; they are used to prepare the processors (above).
 
             errorsCollector.collect().log(LOGGER);
-            target.tracingBuilderInfo(new TracingBuilderInfo(sdkTracerProviderBuilder,
+            target.loggingBuilderInfo(new LoggingBuilderInfo(sdkLoggerProviderBuilder,
                                                              target.attributes().orElseGet(Attributes::builder)));
-        }
 
+        }
     }
 
     static class CustomMethods {
@@ -68,31 +75,30 @@ class OpenTelemetryTracingConfigSupport {
         private CustomMethods() {
         }
 
+        @Prototype.ConfigFactoryMethod
+        static LogRecordExporter createLogRecordExporter(Config config) {
+            return OtlpExporterConfigSupport.CustomMethods.createLogRecordExporter(config);
+        }
+
         @Prototype.ConfigFactoryMethod("processorConfigs")
         static ProcessorConfig createProcessorConfigs(Config config) {
             return OtelConfigSupport.createProcessorConfig(config);
         }
 
-        @Prototype.ConfigFactoryMethod("sampler")
-        static Sampler createSampler(Config config) {
-            return OtelConfigSupport.createSampler(config);
-        }
+        @Prototype.ConfigFactoryMethod("logLimits")
+        static LogLimits createLogLimits(Config config) {
+            var builder = LogLimits.builder();
+            var logLimitsConfig = LogLimitsConfig.create(config);
 
-        @Prototype.ConfigFactoryMethod("spanLimits")
-        static SpanLimits createSpanLimits(Config config) {
-            return OtelConfigSupport.createSpanLimits(config);
-        }
+            logLimitsConfig.maxAttributeValueLength().ifPresent(builder::setMaxAttributeValueLength);
+            logLimitsConfig.maxNumberOfAttributes().ifPresent(builder::setMaxNumberOfAttributes);
 
-        @Prototype.ConfigFactoryMethod("exporterConfigs")
-        static SpanExporter createExporterConfigs(Config config) {
-            return OtlpExporterConfigSupport.CustomMethods.createSpanExporter(config);
+            return builder.build();
         }
 
         @Prototype.ConfigFactoryMethod("attributes")
         static AttributesBuilder createAttributesBuilder(Config config) {
             return OtelConfigSupport.createAttributesBuilder(config);
         }
-
     }
-
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
@@ -26,7 +26,6 @@ import io.opentelemetry.sdk.logs.LogLimits;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.internal.LoggerConfig;
-import io.opentelemetry.sdk.resources.Resource;
 
 class OpenTelemetryLoggingConfigSupport {
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryLoggingConfigSupport.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.logs.LogLimits;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.internal.LoggerConfig;
+import io.opentelemetry.sdk.resources.Resource;
 
 class OpenTelemetryLoggingConfigSupport {
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryMetricsConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryMetricsConfigBlueprint.java
@@ -18,10 +18,12 @@ package io.helidon.telemetry.otelconfig;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 
@@ -31,7 +33,7 @@ import io.opentelemetry.sdk.metrics.export.MetricReader;
 @Prototype.Configured
 @Prototype.Blueprint(decorator = OpenTelemetryMetricsConfigSupport.BuilderDecorator.class)
 @Prototype.CustomMethods(OpenTelemetryMetricsConfigSupport.CustomMethods.class)
-interface OpenTelemetryMetricsConfigBlueprint extends TypedAttributes {
+interface OpenTelemetryMetricsConfigBlueprint {
 
     /**
      * Constructed metric readers.
@@ -56,9 +58,17 @@ interface OpenTelemetryMetricsConfigBlueprint extends TypedAttributes {
      *
      * @return metric exporters
      */
-    @Option.Configured("exporters")
+    @Option.Configured
     @Option.Singular
     Map<String, MetricExporter> exporters();
+
+    /**
+     * Name/value pairs passed to OpenTelemetry.
+     *
+     * @return typed attribute settings
+     */
+    @Option.Configured
+    Optional<AttributesBuilder> attributes();
 
     /**
      * Metric view information, configurable using {@link io.helidon.telemetry.otelconfig.ViewRegistrationConfig}.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryMetricsConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryMetricsConfigSupport.java
@@ -23,6 +23,7 @@ import io.helidon.common.Errors;
 import io.helidon.config.Config;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
@@ -114,18 +115,24 @@ class OpenTelemetryMetricsConfigSupport {
         var otlpExporterConfig = OtlpExporterConfig.create(config);
         var protocolType = otlpExporterConfig.protocol().orElse(OtlpExporterProtocolType.DEFAULT);
         return switch (protocolType) {
-            case HTTP_PROTO -> createHttpProtobufMetricExporter(metricExporterConfig, otlpExporterConfig);
+            case HTTP_PROTO -> createHttpProtobufMetricExporter(metricExporterConfig, OtlpHttpExporterConfig.create(config));
             case GRPC -> createGrpcMetricExporter(metricExporterConfig, otlpExporterConfig);
         };
     }
 
     private static MetricExporter createHttpProtobufMetricExporter(MetricExporterConfig metricExporterConfig,
-                                                                   OtlpExporterConfig exporterConfig) {
+                                                                   OtlpHttpExporterConfig exporterConfig) {
+
+
         var builder = OtlpHttpMetricExporter.builder();
+
+        OtlpExporterConfigSupport.CustomMethods.apply(exporterConfig, builder::setProxyOptions);
+
         OtlpExporterConfigSupport.CustomMethods.apply(exporterConfig,
                                                       builder::setEndpoint,
                                                       builder::setCompression,
                                                       builder::setTimeout,
+                                                      builder::setConnectTimeout,
                                                       builder::addHeader,
                                                       builder::setRetryPolicy,
                                                       builder::setClientTls,
@@ -144,6 +151,7 @@ class OpenTelemetryMetricsConfigSupport {
                                                       builder::setEndpoint,
                                                       builder::setCompression,
                                                       builder::setTimeout,
+                                                      builder::setConnectTimeout,
                                                       builder::addHeader,
                                                       builder::setRetryPolicy,
                                                       builder::setClientTls,
@@ -164,13 +172,6 @@ class OpenTelemetryMetricsConfigSupport {
 
             var sdkMetricsProviderBuilder = SdkMeterProvider.builder();
 
-            var attributesBuilder = Attributes.builder();
-            TypedAttributes.apply(attributesBuilder,
-                                  target.stringAttributes(),
-                                  target.longAttributes(),
-                                  target.doubleAttributes(),
-                                  target.booleanAttributes());
-
             /*
             Defer creation of the readers until here (rather than using a config factory method) because we need the
             exporters to be fully populated first, before preparing the readers, and we cannot be sure that would be
@@ -190,7 +191,8 @@ class OpenTelemetryMetricsConfigSupport {
                     .forEach(viewRegistration -> sdkMetricsProviderBuilder.registerView(viewRegistration.instrumentSelector,
                                                                                         viewRegistration.view));
 
-            target.metricsBuilderInfo(new MetricsBuilderInfo(sdkMetricsProviderBuilder, attributesBuilder));
+            target.metricsBuilderInfo(new MetricsBuilderInfo(sdkMetricsProviderBuilder,
+                                                             target.attributes().orElseGet(Attributes::builder)));
         }
     }
 
@@ -259,6 +261,11 @@ class OpenTelemetryMetricsConfigSupport {
             viewBuilder.setAggregation(viewRegistrationConfig.aggregation());
 
             return new ViewRegistration(viewRegistrationConfig.instrumentSelector(), viewBuilder.build());
+        }
+
+        @Prototype.ConfigFactoryMethod("attributes")
+        static AttributesBuilder createAttributesBuilder(Config config) {
+            return OtelConfigSupport.createAttributesBuilder(config);
         }
     }
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryTracingConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryTracingConfigBlueprint.java
@@ -23,18 +23,19 @@ import java.util.Optional;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 /**
- * OpenTelemetry tracer settings.
+ * OpenTelemetry tracer settings. Optional values left unspecified in the configuration defer to the OpenTelemetry defaults.
  */
 @Prototype.Configured
 @Prototype.Blueprint(decorator = OpenTelemetryTracingConfigSupport.BuilderDecorator.class)
 @Prototype.CustomMethods(OpenTelemetryTracingConfigSupport.CustomMethods.class)
-interface OpenTelemetryTracingConfigBlueprint extends TypedAttributes {
+interface OpenTelemetryTracingConfigBlueprint {
 
     /**
      * Tracing sampler.
@@ -60,7 +61,7 @@ interface OpenTelemetryTracingConfigBlueprint extends TypedAttributes {
     @Option.Access("")
     @Option.Configured("processors")
     @Option.Singular
-    List<SpanProcessorConfig> processorConfigs();
+    List<ProcessorConfig> processorConfigs();
 
     /**
      * Constructed span processors.
@@ -71,10 +72,18 @@ interface OpenTelemetryTracingConfigBlueprint extends TypedAttributes {
     List<SpanProcessor> processors();
 
     /**
+     * Name/value pairs passed to OpenTelemetry.
+     *
+     * @return typed attribute settings
+     */
+    @Option.Configured
+    Optional<AttributesBuilder> attributes();
+
+    /**
      * Span exporters.
      * <p>
      * The key in the map is a unique name--of the user's choice--for the exporter config settings.
-     * The {@link SpanProcessorConfig#exporters()} config setting for a processor config specifies zero
+     * The {@link ProcessorConfig#exporters()} config setting for a processor config specifies zero
      * or more of these names to associate the exporters built from the exporter configs with the processor
      * built from the processor config.
      *

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
@@ -24,7 +24,14 @@ import java.util.Set;
 import io.helidon.common.Errors;
 import io.helidon.config.Config;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.logs.LogRecordProcessor;
+import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -42,11 +49,11 @@ class OtelConfigSupport {
      * specified) all exporters.
      *
      * @param spanProcessorConfig span processor config
-     * @param spanExporters available span exporters
-     * @param errorsCollector error note collector to report exporter names specified to ber used but not present
+     * @param spanExporters       available span exporters
+     * @param errorsCollector     error note collector to report exporter names specified to ber used but not present
      * @return new {@code Processor}
      */
-    static SpanProcessor createSpanProcessor(SpanProcessorConfig spanProcessorConfig,
+    static SpanProcessor createSpanProcessor(ProcessorConfig spanProcessorConfig,
                                              Map<String, SpanExporter> spanExporters,
                                              Errors.Collector errorsCollector) {
 
@@ -71,13 +78,12 @@ class OtelConfigSupport {
                         : SpanExporter.composite(exportersToUse);
 
         return switch (spanProcessorConfig.type()) {
-            case SpanProcessorType.SIMPLE -> SimpleSpanProcessor.create(exporterToUse);
-            case SpanProcessorType.BATCH ->
-                    createBatchSpanProcessor((BatchSpanProcessorConfig) spanProcessorConfig, exporterToUse);
+            case ProcessorType.SIMPLE -> SimpleSpanProcessor.create(exporterToUse);
+            case ProcessorType.BATCH -> createBatchSpanProcessor((BatchProcessorConfig) spanProcessorConfig, exporterToUse);
         };
     }
 
-    static BatchSpanProcessor createBatchSpanProcessor(BatchSpanProcessorConfig config, SpanExporter spanExporter) {
+    static BatchSpanProcessor createBatchSpanProcessor(BatchProcessorConfig config, SpanExporter spanExporter) {
 
         var builder = BatchSpanProcessor.builder(spanExporter);
 
@@ -105,8 +111,8 @@ class OtelConfigSupport {
                                                       .map(Number::doubleValue)
                                                       .orElseThrow()));
             case SamplerType.TRACEIDRATIO -> Sampler.traceIdRatioBased(samplerConfig.param()
-                                                                                 .map(Number::doubleValue)
-                                                                                 .orElseThrow());
+                                                                               .map(Number::doubleValue)
+                                                                               .orElseThrow());
         };
     }
 
@@ -126,13 +132,68 @@ class OtelConfigSupport {
         return builder.build();
     }
 
-    static SpanProcessorConfig createProcessorConfig(Config config) {
+    static ProcessorConfig createProcessorConfig(Config config) {
 
         // Apply the default.
-        return switch (SpanProcessorConfig.create(config).type()) {
-            case SpanProcessorType.BATCH -> BatchSpanProcessorConfig.create(config);
-            case SpanProcessorType.SIMPLE -> SpanProcessorConfig.create(config);
+        return switch (ProcessorConfig.create(config).type()) {
+            case ProcessorType.BATCH -> BatchProcessorConfig.create(config);
+            case ProcessorType.SIMPLE -> ProcessorConfig.create(config);
         };
+    }
+
+    static LogRecordProcessor createLogRecordProcessor(ProcessorConfig processorConfig,
+                                                       Map<String, LogRecordExporter> logRecordExporters,
+                                                       Errors.Collector errorsCollector) {
+        List<LogRecordExporter> exportersToUse = (
+                processorConfig.exporters().isEmpty()
+                        ? logRecordExporters.values().stream()
+                        : processorConfig.exporters().stream()
+                                .filter(logRecordExporters::containsKey)
+                                .map(logRecordExporters::get))
+                .toList();
+
+        Set<String> missingExporterNames = new HashSet<>(processorConfig.exporters());
+        missingExporterNames.removeAll(logRecordExporters.keySet());
+        if (!missingExporterNames.isEmpty()) {
+            errorsCollector.fatal(processorConfig, "Missing exporter(s): " + missingExporterNames);
+        }
+
+        LogRecordExporter exporterToUse = exportersToUse.isEmpty()
+                ? OtlpHttpLogRecordExporter.getDefault() // The factory method below requires an exporter so use OTel's default.
+                : (exportersToUse.size() == 1)
+                        ? exportersToUse.getFirst()
+                        : LogRecordExporter.composite(exportersToUse);
+
+        return switch (processorConfig.type()) {
+            case ProcessorType.SIMPLE -> SimpleLogRecordProcessor.create(exporterToUse);
+            case ProcessorType.BATCH ->
+                    createBatchLogRecordProcessor((BatchProcessorConfig) processorConfig, exporterToUse);
+        };
+    }
+
+    static BatchLogRecordProcessor createBatchLogRecordProcessor(BatchProcessorConfig config,
+                                                                 LogRecordExporter logRecordExporter) {
+
+        var builder = BatchLogRecordProcessor.builder(logRecordExporter);
+
+        config.maxExportBatchSize().ifPresent(builder::setMaxExportBatchSize);
+        config.maxQueueSize().ifPresent(builder::setMaxQueueSize);
+        config.scheduleDelay().ifPresent(builder::setScheduleDelay);
+        config.timeout().ifPresent(builder::setExporterTimeout);
+
+        return builder.build();
+    }
+
+    static AttributesBuilder createAttributesBuilder(Config config) {
+        var typedAttributes = TypedAttributes.create(config);
+        var builder = Attributes.builder();
+
+        typedAttributes.booleanAttributes().forEach(builder::put);
+        typedAttributes.doubleAttributes().forEach(builder::put);
+        typedAttributes.stringAttributes().forEach(builder::put);
+        typedAttributes.longAttributes().forEach(builder::put);
+
+        return builder;
     }
 
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.helidon.builder.api.Prototype;
 import io.helidon.common.Errors;
 import io.helidon.config.Config;
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtelConfigSupport.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.helidon.builder.api.Prototype;
 import io.helidon.common.Errors;
 import io.helidon.config.Config;
 

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.common.configurable.Resource;
 
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.sdk.common.InternalTelemetryVersion;
+import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 
 /**
@@ -49,6 +51,14 @@ interface OtlpExporterConfigBlueprint {
      */
     @Option.Configured
     Optional<Duration> timeout();
+
+    /**
+     * Connection timeout.
+     *
+     * @return connection timeout
+     */
+    @Option.Configured
+    Optional<Duration> connectTimeout();
 
     /**
      * Endpoint of the collector to which the exporter should transmit.
@@ -114,6 +124,22 @@ interface OtlpExporterConfigBlueprint {
     @Option.Configured
     @Option.Default("DEFAULT")
     Optional<OtlpExporterProtocolType> protocol();
+
+    /**
+     * Memory mode.
+     *
+     * @return memory mode
+     */
+    @Option.Configured
+    Optional<MemoryMode> memoryMode();
+
+    /**
+     * Self-monitoring telemetry OpenTelemetry should collect.
+     *
+     * @return telemetry version
+     */
+    @Option.Configured
+    Optional<InternalTelemetryVersion> internalTelemetryVersion();
 
     /**
      * SSL context for the exporter.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpExporterConfigSupport.java
@@ -29,12 +29,18 @@ import io.helidon.config.Config;
 
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.exporter.logging.SystemOutLogRecordExporter;
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogRecordExporter;
 import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingSpanExporter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.exporter.zipkin.ZipkinSpanExporterBuilder;
+import io.opentelemetry.sdk.common.export.ProxyOptions;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 class OtlpExporterConfigSupport {
@@ -52,15 +58,26 @@ class OtlpExporterConfigSupport {
             return OtlpExporterProtocolType.from(config);
         }
 
-        @Prototype.ConfigFactoryMethod("spanExporter")
+        @Prototype.ConfigFactoryMethod
         static SpanExporter createSpanExporter(Config config) {
             SpanExporterConfig exporterConfig = SpanExporterConfig.create(config);
 
             return switch (exporterConfig.type()) {
-                case ExporterType.ZIPKIN -> createZipkinSpanExporter(config);
-                case ExporterType.CONSOLE -> LoggingSpanExporter.create();
-                case ExporterType.LOGGING_OTLP -> OtlpJsonLoggingSpanExporter.create();
-                case ExporterType.OTLP -> createOtlpSpanExporter(config);
+                case SpanExporterType.ZIPKIN -> createZipkinSpanExporter(config);
+                case SpanExporterType.CONSOLE -> LoggingSpanExporter.create();
+                case SpanExporterType.LOGGING_OTLP -> OtlpJsonLoggingSpanExporter.create();
+                case SpanExporterType.OTLP -> createOtlpSpanExporter(config);
+            };
+        }
+
+        @Prototype.ConfigFactoryMethod
+        static LogRecordExporter createLogRecordExporter(Config config) {
+            LogRecordExporterConfig exporterConfig = LogRecordExporterConfig.create(config);
+
+            return switch (exporterConfig.type()) {
+                case CONSOLE -> SystemOutLogRecordExporter.create();
+                case LOGGING_OTLP -> OtlpJsonLoggingLogRecordExporter.create();
+                case OTLP -> createOtlpLogRecordExporter(config);
             };
         }
 
@@ -83,8 +100,17 @@ class OtlpExporterConfigSupport {
             OtlpExporterConfig exporterConfig = OtlpExporterConfig.create(config);
             OtlpExporterProtocolType protocolType = exporterConfig.protocol().orElse(OtlpExporterProtocolType.DEFAULT);
             return switch (protocolType) {
-                case HTTP_PROTO -> createHttpProtobufSpanExporter(exporterConfig);
+                case HTTP_PROTO -> createHttpProtobufSpanExporter(OtlpHttpExporterConfig.create(config));
                 case GRPC -> createGrpcSpanExporter(exporterConfig);
+            };
+        }
+
+        static LogRecordExporter createOtlpLogRecordExporter(Config config) {
+            OtlpExporterConfig exporterConfig = OtlpExporterConfig.create(config);
+            OtlpExporterProtocolType protocolType = exporterConfig.protocol().orElse(OtlpExporterProtocolType.DEFAULT);
+            return switch (protocolType) {
+                case HTTP_PROTO -> createHttpProtobufLogRecordExporter(OtlpHttpExporterConfig.create(config));
+                case GRPC -> createGrpcLogRecordExporter(exporterConfig);
             };
         }
 
@@ -105,12 +131,54 @@ class OtlpExporterConfigSupport {
         }
 
         @SuppressWarnings("checkstyle:ParameterNumber") // we need all of them
-        static SpanExporter createHttpProtobufSpanExporter(OtlpExporterConfig exporterConfig) {
+        static SpanExporter createHttpProtobufSpanExporter(OtlpHttpExporterConfig exporterConfig) {
             var builder = OtlpHttpSpanExporter.builder();
+
+            apply(exporterConfig, builder::setProxy);
+
             apply(exporterConfig,
                   builder::setEndpoint,
                   builder::setCompression,
                   builder::setTimeout,
+                  builder::setConnectTimeout,
+                  builder::addHeader,
+                  builder::setRetryPolicy,
+                  builder::setClientTls,
+                  builder::setTrustedCertificates,
+                  builder::setSslContext,
+                  builder::setMeterProvider);
+
+            return builder.build();
+        }
+
+        static LogRecordExporter createHttpProtobufLogRecordExporter(OtlpHttpExporterConfig exporterConfig) {
+            var builder = OtlpHttpLogRecordExporter.builder();
+
+            apply(exporterConfig, builder::setProxyOptions);
+
+            apply(exporterConfig,
+                  builder::setEndpoint,
+                  builder::setCompression,
+                  builder::setTimeout,
+                  builder::setConnectTimeout,
+                  builder::addHeader,
+                  builder::setRetryPolicy,
+                  builder::setClientTls,
+                  builder::setTrustedCertificates,
+                  builder::setSslContext,
+                  builder::setMeterProvider);
+
+            return builder.build();
+        }
+
+        static LogRecordExporter createGrpcLogRecordExporter(OtlpExporterConfig exporterConfig) {
+            var builder = OtlpGrpcLogRecordExporter.builder();
+
+            apply(exporterConfig,
+                  builder::setEndpoint,
+                  builder::setCompression,
+                  builder::setTimeout,
+                  builder::setConnectTimeout,
                   builder::addHeader,
                   builder::setRetryPolicy,
                   builder::setClientTls,
@@ -128,6 +196,7 @@ class OtlpExporterConfigSupport {
                   builder::setEndpoint,
                   builder::setCompression,
                   builder::setTimeout,
+                  builder::setConnectTimeout,
                   builder::addHeader,
                   builder::setRetryPolicy,
                   builder::setClientTls,
@@ -143,6 +212,7 @@ class OtlpExporterConfigSupport {
                           Consumer<String> doEndpoint,
                           Consumer<String> doCompression,
                           Consumer<Duration> doTimeout,
+                          Consumer<Duration> doConnectTimeout,
                           BiConsumer<String, String> addHeader,
                           Consumer<RetryPolicy> doRetryPolicy,
                           BiConsumer<byte[], byte[]> doClientTls,
@@ -153,6 +223,7 @@ class OtlpExporterConfigSupport {
                   doEndpoint,
                   doCompression,
                   doTimeout,
+                  doConnectTimeout,
                   addHeader,
                   doRetryPolicy,
                   doClientTls,
@@ -160,11 +231,18 @@ class OtlpExporterConfigSupport {
                   doSslContext);
 
         }
+
+        static void apply(OtlpHttpExporterConfig target,
+                          Consumer<ProxyOptions> doProxyOptions) {
+            target.proxyOptions().ifPresent(doProxyOptions);
+        }
+
         @SuppressWarnings("checkstyle:ParameterNumber") // we need all of them
         static void apply(OtlpExporterConfig target,
                           Consumer<String> doEndpoint,
                           Consumer<String> doCompression,
                           Consumer<Duration> doTimeout,
+                          Consumer<Duration> doConnectTimeout,
                           BiConsumer<String, String> addHeader,
                           Consumer<RetryPolicy> doRetryPolicy,
                           BiConsumer<byte[], byte[]> doClientTls,
@@ -179,6 +257,7 @@ class OtlpExporterConfigSupport {
 
             target.headers().forEach(addHeader);
             target.timeout().ifPresent(doTimeout);
+            target.connectTimeout().ifPresent(doConnectTimeout);
             target.retryPolicy().ifPresent(doRetryPolicy);
 
             target.clientTlsPrivateKeyPem()

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpHttpExporterConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OtlpHttpExporterConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ * Copyright (c) 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,23 @@
 
 package io.helidon.telemetry.otelconfig;
 
-import io.helidon.builder.api.Option;
+import java.util.Optional;
+
 import io.helidon.builder.api.Prototype;
 
+import io.opentelemetry.sdk.common.export.ProxyOptions;
+
+/**
+ * Settings common to HTTP-based OTLP exporters.
+ */
 @Prototype.Configured
 @Prototype.Blueprint
-interface SpanExporterConfigBlueprint {
+interface OtlpHttpExporterConfigBlueprint extends OtlpExporterConfigBlueprint {
 
     /**
-     * Span exporter type.
+     * Proxy options.
      *
-     * @return exporter type
+     * @return proxy options
      */
-    @Option.Configured
-    @Option.Default("DEFAULT")
-    SpanExporterType type();
-
+    Optional<ProxyOptions> proxyOptions();
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ProcessorConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ProcessorConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,30 +22,30 @@ import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 
 /**
- * Generic configuration for a {@link io.opentelemetry.sdk.trace.SpanProcessor}, linked to a
- * {@link io.opentelemetry.sdk.trace.export.SpanExporter} by its name in the configuration.
+ * Generic configuration for a processor such as a {@link io.opentelemetry.sdk.trace.SpanProcessor}, linked to an
+ * exporter such as a {@link io.opentelemetry.sdk.trace.export.SpanExporter} by its name in the configuration.
  */
 @Prototype.Blueprint
 @Prototype.Configured
-interface SpanProcessorConfigBlueprint {
+interface ProcessorConfigBlueprint {
 
     /**
-     * Name(s) of the span exporter(s) this span processor should use; specifying no names uses all configured exporters (or
+     * Name(s) of the  exporter(s) this processor should use; specifying no names uses all configured exporters (or
      * if no exporters are configured, the default OpenTelemetry exporter(s)).
      * <p>
      * Each name must be the name of one of the configured {@link OpenTelemetryTracingConfig#exporterConfigs()}.
      *
-     * @return span exporter name
+     * @return exporter name
      */
     @Option.Configured
     List<String> exporters();
 
     /**
-     * Span processor type.
-     * @return span processor type
+     * Processor type.
+     * @return processor type
      */
     @Option.Configured
     @Option.Required
-    SpanProcessorType type();
+    ProcessorType type();
 
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ProcessorType.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/ProcessorType.java
@@ -16,20 +16,24 @@
 
 package io.helidon.telemetry.otelconfig;
 
-import io.helidon.builder.api.Option;
-import io.helidon.builder.api.Prototype;
+/**
+ * Processor type. Batch is default for production.
+ */
+public enum ProcessorType {
 
-@Prototype.Configured
-@Prototype.Blueprint
-interface SpanExporterConfigBlueprint {
+    /*
+    Enum values are chosen to be the upper-case version of the OTel setting values so Helidon's built-in enum config mapping
+    works.
+     */
 
     /**
-     * Span exporter type.
-     *
-     * @return exporter type
+     * Simple Processor.
      */
-    @Option.Configured
-    @Option.Default("DEFAULT")
-    SpanExporterType type();
+    SIMPLE,
+    /**
+     * Batch Processor.
+     */
+    BATCH;
 
 }
+

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/SpanExporterType.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/SpanExporterType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ package io.helidon.telemetry.otelconfig;
  * <p>
  * See <a href="https://opentelemetry.io/docs/languages/java/configuration/#properties-exporters">OTel exporters</a>.
  */
-public enum ExporterType {
+public enum SpanExporterType {
 
     /*
     Enum values are chosen to be the upper-case version of the OTel setting values so Helidon's built-in enum config mapping
@@ -49,6 +49,6 @@ public enum ExporterType {
      */
     LOGGING_OTLP;
 
-    static final ExporterType DEFAULT = OTLP;
+    static final SpanExporterType DEFAULT = OTLP;
 
 }

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/TypedAttributesBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/TypedAttributesBlueprint.java
@@ -19,31 +19,21 @@ package io.helidon.telemetry.otelconfig;
 import java.util.Map;
 
 import io.helidon.builder.api.Option;
-
-import io.opentelemetry.api.common.AttributesBuilder;
+import io.helidon.builder.api.Prototype;
 
 /**
  * Abstraction of typed attributes settable on OpenTelemetry elements.
  */
-interface TypedAttributes {
-
-    static void apply(AttributesBuilder attributesBuilder,
-                      Map<String, String> stringAttributes,
-                      Map<String, Long> longAttributes,
-                      Map<String, Double> doubleAttributes,
-                      Map<String, Boolean> booleanAttributes) {
-        stringAttributes.forEach(attributesBuilder::put);
-        longAttributes.forEach(attributesBuilder::put);
-        doubleAttributes.forEach(attributesBuilder::put);
-        booleanAttributes.forEach(attributesBuilder::put);
-    }
+@Prototype.Blueprint
+@Prototype.Configured
+interface TypedAttributesBlueprint {
 
     /**
      * String attributes.
      *
      * @return string attributes
      */
-    @Option.Configured("attributes.strings")
+    @Option.Configured("strings")
     @Option.Singular
     Map<String, String> stringAttributes();
 
@@ -52,7 +42,7 @@ interface TypedAttributes {
      *
      * @return boolean attributes
      */
-    @Option.Configured("attributes.booleans")
+    @Option.Configured("booleans")
     @Option.Singular
     Map<String, Boolean> booleanAttributes();
 
@@ -61,7 +51,7 @@ interface TypedAttributes {
      *
      * @return long attributes
      */
-    @Option.Configured("attributes.longs")
+    @Option.Configured("longs")
     @Option.Singular
     Map<String, Long> longAttributes();
 
@@ -70,7 +60,7 @@ interface TypedAttributes {
      *
      * @return double attributes
      */
-    @Option.Configured("attributes.doubles")
+    @Option.Configured("doubles")
     @Option.Singular
     Map<String, Double> doubleAttributes();
 

--- a/telemetry/opentelemetry-config/src/main/java/module-info.java
+++ b/telemetry/opentelemetry-config/src/main/java/module-info.java
@@ -24,7 +24,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Description("Support for Telemetry")
 @Features.Flavor({HelidonFlavor.SE, HelidonFlavor.MP})
 @Features.Path({"Telemetry", "OpenTelemetry", "Config"})
-@Features.Incubating
+@Features.Preview
 module io.helidon.telemetry.otelconfig {
 
     requires io.helidon.builder.api;
@@ -39,6 +39,7 @@ module io.helidon.telemetry.otelconfig {
     requires io.opentelemetry.extension.trace.propagation;
     requires io.opentelemetry.sdk;
     requires io.opentelemetry.sdk.common;
+    requires io.opentelemetry.sdk.logs;
     requires io.opentelemetry.sdk.metrics;
     requires io.opentelemetry.sdk.trace;
     requires io.opentelemetry.semconv;
@@ -55,6 +56,7 @@ module io.helidon.telemetry.otelconfig {
     requires static io.opentelemetry.exporter.logging.otlp;
     requires static io.opentelemetry.exporter.otlp;
     requires static io.opentelemetry.exporter.zipkin;
+    requires io.opentelemetry.common;
 
     exports io.helidon.telemetry.otelconfig;
 

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestAttributeValueConversions.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestAttributeValueConversions.java
@@ -22,13 +22,8 @@ import java.util.stream.Stream;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
-import io.helidon.testing.junit5.Testing;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import io.opentelemetry.sdk.metrics.export.MetricReader;
-import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -94,11 +89,11 @@ class TestAttributeValueConversions {
             .prototype();
 
     static final OpenTelemetryTracingConfig tracingConfig = openTelemetryConfig
-            .tracingConfig()
+            .tracing()
             .get();
 
     static final OpenTelemetryMetricsConfig metricsConfig = openTelemetryConfig
-            .metricsConfig()
+            .metrics()
             .get();
 
     static final Map<AttributeKey<?>, Object> tracingAttrs = tracingConfig.tracingBuilderInfo()

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
@@ -87,7 +87,7 @@ class TestBasicConfig {
                    retryPolicyConfig.maxBackoff(),
                    OptionalMatcher.optionalValue(is(Duration.ofMinutes(1))));
 
-        OpenTelemetryTracingConfig openTelemetryTracingConfig = openTelemetryConfig.tracingConfig().orElseThrow();
+        OpenTelemetryTracingConfig openTelemetryTracingConfig = openTelemetryConfig.tracing().orElseThrow();
         assertThat("Helidon OTel tracing", openTelemetryTracingConfig, is(notNullValue()));
 
         assertThat("Exporters",

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestLoggingConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestLoggingConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.telemetry.otelconfig;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.testing.junit5.OptionalMatcher;
+import io.helidon.config.Config;
+
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.sdk.logs.LogLimits;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+class TestLoggingConfig {
+
+    @Test
+    void testLoggingConfig() {
+        var config = Config.just("""
+                                         telemetry:
+                                           service: test-tel-logging
+                                           global: false
+                                           signals:
+                                             logging:
+                                               minimum-severity: TRACE
+                                               log-limits:
+                                                 max-attribute-value-length: 20
+                                                 max-number-of-attributes: 14
+                                               processors:
+                                                 - type: batch
+                                                   schedule-delay: PT10S
+                                                   max-queue-size: 15
+                                                   max-export-batch-size: 5
+                                                   timeout: PT30S
+                                                 - type: simple
+                                               exporters:
+                                                 - name: exp-1
+                                                   endpoint: "http://host:1234"
+                                         """,
+                                 MediaTypes.APPLICATION_YAML);
+
+        var otelConfig = OpenTelemetryConfig.create(config.get("telemetry"));
+
+        assertThat("Logging in OTel config", otelConfig.logging(), OptionalMatcher.optionalPresent());
+
+        OpenTelemetryLoggingConfig loggingConfig = otelConfig.logging().get();
+
+        assertThat("Logging processors", loggingConfig.processors(), hasSize(2));
+
+        assertThat("Logging processor", loggingConfig.processors().getFirst().toString(),
+                   allOf(containsString("endpoint=http://host:1234"),
+                         containsString("")));
+
+        assertThat("Log limits", loggingConfig.logLimits(),
+                   OptionalMatcher.optionalValue(allOf(maxNumberOfAttributes(is(14)),
+                                                       maxAttributeValueLength(is(20)))));
+
+        assertThat("Severity", loggingConfig.minimumSeverity(), OptionalMatcher.optionalValue(is(Severity.TRACE)));
+
+
+    }
+
+    static Matcher<LogLimits> maxNumberOfAttributes(Matcher<? super Integer> matcher) {
+        return new FeatureMatcher<LogLimits, Integer>(matcher, "an integer value that ","maxNumberOfAttributes") {
+            @Override
+            protected Integer featureValueOf(LogLimits actual) {
+                return actual.getMaxNumberOfAttributes();
+            }
+        };
+    }
+
+    static Matcher<LogLimits> maxAttributeValueLength(Matcher<? super Integer> matcher) {
+        return new FeatureMatcher<LogLimits, Integer>(matcher, "an integer value that ","maxAttributeValueLength") {
+            @Override
+            protected Integer featureValueOf(LogLimits actual) {
+                return actual.getMaxAttributeValueLength();
+            }
+        };
+    }
+
+
+}

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMetricsConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestMetricsConfig.java
@@ -72,9 +72,9 @@ class TestMetricsConfig {
 
         OpenTelemetryConfig otelConfig = OpenTelemetryConfig.create(config.get("telemetry"));
 
-        assertThat("Metrics config in OTel config", otelConfig.metricsConfig(), OptionalMatcher.optionalPresent());
+        assertThat("Metrics config in OTel config", otelConfig.metrics(), OptionalMatcher.optionalPresent());
 
-        OpenTelemetryMetricsConfig metricsConfig = otelConfig.metricsConfig().get();
+        OpenTelemetryMetricsConfig metricsConfig = otelConfig.metrics().get();
 
         assertThat("Metric readers", metricsConfig.readers(), hasSize(1));
 

--- a/telemetry/opentelemetry-logging-jul-appender/pom.xml
+++ b/telemetry/opentelemetry-logging-jul-appender/pom.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.telemetry</groupId>
+        <artifactId>helidon-telemetry-project</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-telemetry-opentelemetry-logging-jul-appender</artifactId>
+    <name>Helidon OpenTelemetry Logging Appender for java.util.logging</name>
+
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.telemetry</groupId>
+            <artifactId>helidon-telemetry-opentelemetry-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>io.helidon.common.testing</groupId>-->
+<!--            <artifactId>helidon-common-testing-junit5</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>io.helidon.testing</groupId>-->
+<!--            <artifactId>helidon-testing-junit5</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+<!--                        <path>-->
+<!--                            <groupId>io.helidon.config.metadata</groupId>-->
+<!--                            <artifactId>helidon-config-metadata-codegen</artifactId>-->
+<!--                            <version>${helidon.version}</version>-->
+<!--                        </path>-->
+<!--                        <path>-->
+<!--                            <groupId>io.helidon.builder</groupId>-->
+<!--                            <artifactId>helidon-builder-codegen</artifactId>-->
+<!--                            <version>${helidon.version}</version>-->
+<!--                        </path>-->
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+<!--                    <dependency>-->
+<!--                        <groupId>io.helidon.config.metadata</groupId>-->
+<!--                        <artifactId>helidon-config-metadata-codegen</artifactId>-->
+<!--                        <version>${helidon.version}</version>-->
+<!--                    </dependency>-->
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+<!--                    <dependency>-->
+<!--                        <groupId>io.helidon.builder</groupId>-->
+<!--                        <artifactId>helidon-builder-codegen</artifactId>-->
+<!--                        <version>${helidon.version}</version>-->
+<!--                    </dependency>-->
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.common.features</groupId>
+                        <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/telemetry/opentelemetry-logging-jul-appender/src/main/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/OtelJulHandler.java
+++ b/telemetry/opentelemetry-logging-jul-appender/src/main/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/OtelJulHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.opentelemetry.logging.jul.appender;
+
+import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+
+class OtelJulHandler extends Handler {
+
+    private static final Map<Level, Severity> LEVELS = Map.of(
+            Level.SEVERE, Severity.ERROR,
+            Level.WARNING, Severity.WARN,
+            Level.INFO, Severity.INFO,
+            Level.CONFIG, Severity.INFO,
+            Level.FINE, Severity.DEBUG,
+            Level.FINER, Severity.DEBUG,
+            Level.FINEST, Severity.TRACE);
+
+    private final Logger otelLogger;
+
+    OtelJulHandler(OpenTelemetry openTelemetry) {
+        otelLogger = openTelemetry
+                .getLogsBridge()
+                .loggerBuilder("jul")
+                .build();
+    }
+
+    static OtelJulHandler create(OpenTelemetry openTelemetry) {
+        return new OtelJulHandler(openTelemetry);
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        if (!isLoggable(record)) {
+            return;
+        }
+        LogRecordBuilder builder = otelLogger.logRecordBuilder();
+        builder.setBody(record.getMessage())
+                .setSeverity(LEVELS.get(record.getLevel()))
+                .setTimestamp(record.getMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+
+        builder.setAttribute("logger.name", record.getLoggerName());
+        builder.setAttribute("thread.id", record.getLongThreadID());
+        if (record.getThrown() != null) {
+            builder.setAttribute("exception.message", record.getThrown().getMessage());
+            builder.setAttribute("exception", record.getThrown().toString());
+        }
+        builder.emit();
+    }
+
+    @Override
+    public void flush() {
+        // Nothing to do here with OpenTelemetry.
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do here with OpenTelemetry.
+    }
+}

--- a/telemetry/opentelemetry-logging-jul-appender/src/main/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/OtelJulHandlerProvider.java
+++ b/telemetry/opentelemetry-logging-jul-appender/src/main/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/OtelJulHandlerProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.opentelemetry.logging.jul.appender;
+
+import java.util.logging.LogManager;
+
+import io.helidon.service.registry.Service;
+
+import io.opentelemetry.api.OpenTelemetry;
+
+@Service.Singleton
+@Service.RunLevel(Service.RunLevel.STARTUP)
+class OtelJulHandlerProvider {
+
+    @Service.Inject
+    OtelJulHandlerProvider(OpenTelemetry openTelemetry) {
+        var handler = OtelJulHandler.create(openTelemetry);
+        var rootLogger = LogManager.getLogManager().getLogger("");
+        rootLogger.setUseParentHandlers(false);
+        rootLogger.addHandler(handler);
+    }
+
+}

--- a/telemetry/opentelemetry-logging-jul-appender/src/main/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/package-info.java
+++ b/telemetry/opentelemetry-logging-jul-appender/src/main/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * OpenTelemetry logging support for java.util.logging.
+ */
+package io.helidon.telemetry.opentelemetry.logging.jul.appender;

--- a/telemetry/opentelemetry-logging-jul-appender/src/main/java/module-info.java
+++ b/telemetry/opentelemetry-logging-jul-appender/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.helidon.common.features.api.Features;
+import io.helidon.common.features.api.HelidonFlavor;
+
+/**
+ * OpenTelemetry Log support for java.util.logging.
+ */
+@Features.Name("Telemetry")
+@Features.Description("OpenTelemetry JUL Support")
+@Features.Flavor({HelidonFlavor.SE, HelidonFlavor.MP})
+@Features.Path({"Telemetry", "OpenTelemetry", "Logging", "JUL"})
+@Features.Preview
+module io.helidon.telemetry.opentelemetry.logging.jul.appender {
+
+    requires io.helidon.common;
+    requires io.helidon.service.registry;
+
+    requires java.logging;
+    requires io.opentelemetry.api;
+    requires io.helidon.common.features.api;
+}

--- a/telemetry/opentelemetry-logging-jul-appender/src/test/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/TestOtelJul.java
+++ b/telemetry/opentelemetry-logging-jul-appender/src/test/java/io/helidon/telemetry/opentelemetry/logging/jul/appender/TestOtelJul.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.opentelemetry.logging.jul.appender;
+
+import io.helidon.service.registry.Services;
+import io.helidon.telemetry.otelconfig.OpenTelemetryConfig;
+import io.helidon.telemetry.otelconfig.OpenTelemetryLoggingConfig;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+
+class TestOtelJul {
+
+
+    @Test
+    void testHandlerInit() {
+
+        var inMemoryExporter = InMemoryLogRecordExporter.create();
+
+        var loggingConfig = OpenTelemetryLoggingConfig.builder()
+                .addProcessor(SimpleLogRecordProcessor.builder(inMemoryExporter).build())
+                .build();
+
+        var openTelemetryConfig = OpenTelemetryConfig.builder()
+                .service("test-service")
+                .logging(loggingConfig)
+                .build();
+
+        Services.set(OpenTelemetry.class, openTelemetryConfig.openTelemetry());
+
+        new OtelJulHandlerProvider(openTelemetryConfig.openTelemetry());
+
+        java.util.logging.Logger.getLogger("test-logger").log(java.util.logging.Level.INFO, "log message 1");
+
+        var records = inMemoryExporter.getFinishedLogRecordItems();
+
+        assertThat("Retrieved records", records, hasSize(greaterThan(0)));
+
+    }
+}
+

--- a/telemetry/pom.xml
+++ b/telemetry/pom.xml
@@ -31,6 +31,7 @@
 
     <modules>
         <module>opentelemetry-config</module>
+        <module>opentelemetry-logging-jul-appender</module>
         <module>testing</module>
     </modules>
 

--- a/webserver/observe/config/pom.xml
+++ b/webserver/observe/config/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+ <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2022, 2026 Oracle and/or its affiliates.
 
@@ -28,6 +28,10 @@
     <name>Helidon WebServer Observe Config</name>
     <description>Information from configuration (secured by default)</description>
 
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.webserver.observe</groupId>
@@ -38,13 +42,12 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <scope>provided</scope>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-jsonp</artifactId>
+            <artifactId>helidon-http-media-json</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common.features</groupId>

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserverConfigBlueprint.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigObserverConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,18 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.webserver.observe.ObserverConfigBase;
 import io.helidon.webserver.observe.spi.ObserveProvider;
 
+/**
+ * Configuration of Config Observer.
+ */
 @Prototype.Blueprint
 @Prototype.Configured(root = false, value = "config")
 @Prototype.Provides(ObserveProvider.class)
 interface ConfigObserverConfigBlueprint extends ObserverConfigBase, Prototype.Factory<ConfigObserver> {
+    /**
+     * Endpoint this observer is available on.
+     *
+     * @return the observer endpoint
+     */
     @Option.Configured
     @Option.Default("config")
     String endpoint();

--- a/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
+++ b/webserver/observe/config/src/main/java/io/helidon/webserver/observe/config/ConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import io.helidon.config.ConfigValue;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.NotFoundException;
 import io.helidon.http.media.EntityWriter;
-import io.helidon.http.media.jsonp.JsonpSupport;
+import io.helidon.http.media.json.JsonSupport;
+import io.helidon.json.JsonObject;
 import io.helidon.service.registry.Services;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
@@ -35,14 +36,8 @@ import io.helidon.webserver.http.SecureHandler;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-
 class ConfigService implements HttpService {
-    private static final EntityWriter<JsonObject> WRITER = JsonpSupport.serverResponseWriter();
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
+    private static final EntityWriter<JsonObject> WRITER = JsonSupport.serverResponseWriter();
 
     private final List<Pattern> secretPatterns;
     private final String profile;
@@ -70,10 +65,10 @@ class ConfigService implements HttpService {
 
         ConfigValue<String> value = config.get().get(name).asString();
         if (value.isPresent()) {
-            JsonObjectBuilder json = JSON.createObjectBuilder()
-                    .add("name", name);
+            var json = JsonObject.builder()
+                    .set("name", name);
 
-            json.add("value", obfuscate(name, value.get()));
+            json.set("value", obfuscate(name, value.get()));
             write(req, res, json.build());
         } else {
             throw new NotFoundException("Config value for key: " + name);
@@ -84,16 +79,16 @@ class ConfigService implements HttpService {
         Map<String, String> mapOfValues = new HashMap<>(config.get().asMap()
                                                                 .orElseGet(Map::of));
 
-        JsonObjectBuilder json = JSON.createObjectBuilder();
+        var json = JsonObject.builder();
 
-        mapOfValues.forEach((key, value) -> json.add(key, obfuscate(key, value)));
+        mapOfValues.forEach((key, value) -> json.set(key, obfuscate(key, value)));
 
         write(req, res, json.build());
     }
 
     private void profile(ServerRequest req, ServerResponse res) {
-        JsonObject profile = JSON.createObjectBuilder()
-                .add("name", this.profile)
+        JsonObject profile = JsonObject.builder()
+                .set("name", this.profile)
                 .build();
 
         write(req, res, profile);
@@ -111,7 +106,7 @@ class ConfigService implements HttpService {
 
     private void write(ServerRequest req, ServerResponse res, JsonObject json) {
         res.header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF);
-        WRITER.write(JsonpSupport.JSON_OBJECT_TYPE,
+        WRITER.write(JsonSupport.JSON_OBJECT_TYPE,
                      json,
                      res.outputStream(),
                      req.headers(),

--- a/webserver/observe/config/src/main/java/module-info.java
+++ b/webserver/observe/config/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,12 @@ import io.helidon.common.features.api.HelidonFlavor;
 module io.helidon.webserver.observe.config {
     requires static io.helidon.common.features.api;
 
-    requires io.helidon.http.media.jsonp;
+    requires io.helidon.json;
     requires io.helidon.webserver;
 
     requires transitive io.helidon.common.config;
     requires transitive io.helidon.webserver.observe;
+    requires io.helidon.http.media.json;
 
     exports io.helidon.webserver.observe.config;
 

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthHandler.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/HealthHandler.java
@@ -20,13 +20,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import io.helidon.common.GenericType;
 import io.helidon.health.HealthCheck;
 import io.helidon.health.HealthCheckResponse;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HtmlEncoder;
 import io.helidon.http.Status;
 import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.json.JsonSupport;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.webserver.http.Handler;
@@ -34,7 +34,6 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 
 class HealthHandler implements Handler {
-    static final GenericType<JsonObject> JSON_OBJECT_TYPE = GenericType.create(JsonObject.class);
     private static final System.Logger LOGGER = System.getLogger(HealthHandler.class.getName());
 
     private final EntityWriter<JsonObject> entityWriter;
@@ -88,7 +87,7 @@ class HealthHandler implements Handler {
                 .header(HeaderValues.X_CONTENT_TYPE_OPTIONS_NOSNIFF);
 
         if (details) {
-            entityWriter.write(JSON_OBJECT_TYPE,
+            entityWriter.write(JsonSupport.JSON_OBJECT_TYPE,
                                toJson(status, responses),
                                res.outputStream(),
                                req.headers(),

--- a/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/SingleCheckHandler.java
+++ b/webserver/observe/health/src/main/java/io/helidon/webserver/observe/health/SingleCheckHandler.java
@@ -28,6 +28,7 @@ import io.helidon.http.HtmlEncoder;
 import io.helidon.http.NotFoundException;
 import io.helidon.http.Status;
 import io.helidon.http.media.EntityWriter;
+import io.helidon.http.media.json.JsonSupport;
 import io.helidon.json.JsonObject;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.ServerRequest;
@@ -84,7 +85,7 @@ class SingleCheckHandler implements Handler {
 
         if (details) {
             try (OutputStream out = res.outputStream()) {
-                entityWriter.write(HealthHandler.JSON_OBJECT_TYPE,
+                entityWriter.write(JsonSupport.JSON_OBJECT_TYPE,
                                    HealthHelper.toJson(check.name(), response),
                                    out,
                                    req.headers(),


### PR DESCRIPTION
### Description

OpenTelemetry logging intercepts existing logging frameworks, captures the log records, then transforms them for transmission via OTLP to backends.

OTel itself provides such appenders for log4j and logback but not for JUL.

This PR adds a JUL `Handler` to act as an Otel appender for JUL and a `@Service.Singleton` with init code to plug the handler into the root JUL logger during startup.

### Documentation
TBD
